### PR TITLE
Bump all docker/* actions to latest majors (consolidate #81-#85)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,14 +40,14 @@ jobs:
       uses: actions/checkout@v6
     - name: Set up QEMU
       if: ${{ matrix.platform }} == 'linux/arm64'
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3.12.0
+      uses: docker/setup-buildx-action@v4.0.0
     
     - name: Log into GITHUB registry
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3.7.0
+      uses: docker/login-action@v4.0.0
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
           fi
     - name: Log into Docker Hub
       if: steps.check_secrets.outputs.secrets_available == 'true'
-      uses: docker/login-action@v3.7.0
+      uses: docker/login-action@v4.0.0
       with:
         registry: docker.io
         username: ${{ secrets.DOCKERHUB_REGISTRY_USERNAME }}
@@ -70,7 +70,7 @@ jobs:
     
     - name: Extract Docker metadata
       id: meta
-      uses: docker/metadata-action@v5.10.0
+      uses: docker/metadata-action@v6.0.0
       with:
         images: ghcr.io/${{ env.IMAGE_NAME }}
     - name: Debug tags
@@ -105,7 +105,7 @@ jobs:
       run: echo "tag=${BASE_TAG}" >> $GITHUB_OUTPUT
     - name: Build Docker image for platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
       id: build_image
-      uses: docker/build-push-action@v6.19.2
+      uses: docker/build-push-action@v7.0.0
       with:
         context: .
         file: Dockerfile
@@ -136,7 +136,7 @@ jobs:
           docker run --rm "$IMAGE" postgres --version
         fi
     - name: Push image to GITHUB registry
-      uses: docker/build-push-action@v6.19.2
+      uses: docker/build-push-action@v7.0.0
       with:
         context: .
         build-args: |
@@ -150,7 +150,7 @@ jobs:
     
     - name: Push image to Docker Hub
       if: steps.check_secrets.outputs.secrets_available == 'true'
-      uses: docker/build-push-action@v6.19.2
+      uses: docker/build-push-action@v7.0.0
       with:
         context: .
         build-args: |


### PR DESCRIPTION
## Summary

Consolidates the five open Dependabot PRs into a single change, since they all edit the same `docker.yaml` and merging them one-by-one would trigger five separate 8-cell matrix runs on `main`.

| Action | From | To | Count |
|--------|------|-----|-------|
| `docker/setup-qemu-action` | v3 | v4 | 1 |
| `docker/setup-buildx-action` | v3.12.0 | v4.0.0 | 1 |
| `docker/login-action` | v3.7.0 | v4.0.0 | 2 |
| `docker/metadata-action` | v5.10.0 | v6.0.0 | 1 |
| `docker/build-push-action` | v6.19.2 | v7.0.0 | 3 |

## Breaking changes reviewed

All five are major bumps whose shared headline change is **Node 24 as the action runtime** (requires Actions Runner ≥ v2.327.1, already satisfied on github-hosted `ubuntu-latest`).

- **setup-buildx-action v4 / metadata-action v6 / build-push-action v7**: removed deprecated inputs/outputs/envs. The workflow uses only standard inputs (`images:`, `context:`, `build-args:`, `push:`, `tags:`, `labels:`, `cache-from/to`) — none of the removed ones are referenced, so no behavioral impact.
- **metadata-action v6**: `#` inside list values is now preserved while full-line `#` comments still work — we have no comments in list inputs.
- **login-action v4**: ESM + AWS SDK bumps — we use only `registry/username/password`, unaffected.

## Verification

- Diff is **8 lines**, all version strings only (verified: no other content changed).
- No old versions remain (`grep` confirmed).
- CI on this PR runs the full 8-cell matrix on top of the now-green `main` (#86 merged) — green here proves the bumps are safe end-to-end.

## Notes

- The five Dependabot PRs (#81-#85) show failing CI because their branches were created **before** #86 landed (they still carry the broken trixie path). Merging this consolidated PR and closing them avoids chasing stale red status on each.
- Closes #81, #82, #83, #84, #85.
