### PR TITLE
CI hardening: shrink build context, fix smoke-test, add Trivy + cosign

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# The Dockerfile does not COPY/ADD anything from the repository, so the build
+# context only needs the Dockerfile itself. Excluding everything else keeps
+# the context tiny (a few KB instead of ~200 MB) and, importantly, prevents
+# the local Postgres runtime data under examples/docker/patroni-data* (which
+# is gitignored but present on disk) from being uploaded to the builder.
+*
+!Dockerfile

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -130,12 +130,21 @@ jobs:
         if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
           echo "ARM64 → use QEMU"
           docker run --rm --platform linux/arm64 "$IMAGE" patroni --version
-          docker run --rm --platform linux/arm64 "$IMAGE" postgres --version
+          docker run --rm --platform linux/arm64 --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
         else
           docker run --rm "$IMAGE" patroni --version
-          docker run --rm "$IMAGE" postgres --version
+          docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
         fi
+    - name: Scan image for vulnerabilities (Trivy)
+      if: github.event_name == 'pull_request'
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        image-ref: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
+        severity: HIGH,CRITICAL
+        exit-code: '1'
+        ignore-unfixed: true
     - name: Push image to GITHUB registry
+      id: push-ghcr
       uses: docker/build-push-action@v7.0.0
       with:
         context: .
@@ -161,4 +170,15 @@ jobs:
           GITHUB_SHA=${{ github.sha }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: docker.io/${{ env.LOWER_IMAGE_TAG }}
+
+    - name: Install cosign
+      if: github.event_name != 'pull_request'
+      uses: sigstore/cosign-installer@v4.1.2
+
+    - name: Sign published GHCR image
+      if: github.event_name != 'pull_request'
+      env:
+        DIGEST: ${{ steps.push-ghcr.outputs.digest }}
+      run: |
+        cosign sign --yes "ghcr.io/${{ env.IMAGE_NAME }}@${DIGEST}"
     

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,18 +3,18 @@ name: Build Docker images and push to ghcr.io
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - '*'
+      - '*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Image tag'
+        description: Image tag
         required: false
         default: ''
   pull_request:
     branches:
-    - main
+      - main
 
 env:
 
@@ -31,154 +31,153 @@ jobs:
     strategy:
       matrix:
         platform: [linux/amd64, linux/arm64]
-        distro: [trixie,alpine]
-        pg_version: ["17.6","18.0"]
-        patroni_version: ["4.0.7"]
-    
+        distro: [trixie, alpine]
+        pg_version: ['17.6', '18.0']
+        patroni_version: [4.0.7]
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-    - name: Set up QEMU
-      if: ${{ matrix.platform }} == 'linux/arm64'
-      uses: docker/setup-qemu-action@v4
-    
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4.0.0
-    
-    - name: Log into GITHUB registry
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v4.0.0
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Check if Docker Hub secrets are set
-      id: check_secrets
-      run: |
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up QEMU
+        if: ${{ matrix.platform }} == 'linux/arm64'
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Log into GITHUB registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if Docker Hub secrets are set
+        id: check_secrets
+        run: |
           if [ -n "${{ secrets.DOCKERHUB_REGISTRY_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}" ]; then
           echo "secrets_available=true" >> $GITHUB_OUTPUT
           else
              echo "secrets_available=false" >> $GITHUB_OUTPUT
           fi
-    - name: Log into Docker Hub
-      if: steps.check_secrets.outputs.secrets_available == 'true'
-      uses: docker/login-action@v4.0.0
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKERHUB_REGISTRY_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
-    
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v6.0.0
-      with:
-        images: ghcr.io/${{ env.IMAGE_NAME }}
-    - name: Debug tags
-      run: |
-        echo "Tags:"
-        for tag in ${{ steps.meta.outputs.tags }}; do
-        echo "$tag"
-        done
-    - name: Extract tags without registry and image name
-      id: extract-tags
-      run: |
-        echo "${{ steps.meta.outputs.tags }}" |  tr ',' '\n' | sed 's|.*/||; s|.*:||' > tags.txt
-        echo "TAGS=$(cat tags.txt | tr '\n' ',' | sed 's|,$||')" >> $GITHUB_ENV
-    - name: Override base tag with custom input (if provided)
-      run: |
-        BASE_TAG="${{ env.TAGS }}"
-        if [ -n "${{ inputs.tag }}" ]; then
-          BASE_TAG="${{ inputs.tag }}"
-          echo "Custom tag '${{ inputs.tag }}' will be use as base tag"
-        else
-          echo "Custom tag is not set → use tag from metadata: $BASE_TAG"
-        fi
-        echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
+      - name: Log into Docker Hub
+        if: steps.check_secrets.outputs.secrets_available == 'true'
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
 
-    - name: Build final LOWER_IMAGE_TAG
-      run: |
-        FINAL="${{ env.IMAGE_NAME }}:${BASE_TAG}-${{ matrix.pg_version }}-${{ matrix.patroni_version }}-${{ matrix.distro }}"
-        echo "LOWER_IMAGE_TAG=$(echo "$FINAL" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-        echo "Final tag → ghcr.io/${{ env.LOWER_IMAGE_TAG }}"
-    - name: Export final base tag
-      id: set-tag
-      run: echo "tag=${BASE_TAG}" >> $GITHUB_OUTPUT
-    - name: Build Docker image for platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
-      id: build_image
-      uses: docker/build-push-action@v7.0.0
-      with:
-        context: .
-        file: Dockerfile
-        build-args: |
-          DISTRO=${{ matrix.distro }}
-          PG_VERSION=${{ matrix.pg_version }}
-          PATRONI_VERSION=${{ matrix.patroni_version }}
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.sha }}
-        platforms: ${{ matrix.platform }}
-        load: ${{ github.event_name == 'pull_request' }}
-        push: false
-        tags: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-    - name: Test Docker image platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
-      if: github.event_name == 'pull_request'
-      run: |
-        IMAGE="ghcr.io/${{ env.LOWER_IMAGE_TAG }}"
-        echo "Testing image: $IMAGE  (platform: ${{ matrix.platform }})"
-        if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
-          echo "ARM64 → use QEMU"
-          docker run --rm --platform linux/arm64 "$IMAGE" patroni --version
-          docker run --rm --platform linux/arm64 --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
-        else
-          docker run --rm "$IMAGE" patroni --version
-          docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
-        fi
-    - name: Scan image for vulnerabilities (Trivy)
-      if: github.event_name == 'pull_request'
-      uses: aquasecurity/trivy-action@v0.36.0
-      with:
-        image-ref: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
-        severity: HIGH,CRITICAL
-        exit-code: '1'
-        ignore-unfixed: true
-    - name: Push image to GITHUB registry
-      id: push-ghcr
-      uses: docker/build-push-action@v7.0.0
-      with:
-        context: .
-        build-args: |
-          DISTRO=${{ matrix.distro }}
-          PG_VERSION=${{ matrix.pg_version }}
-          PATRONI_VERSION=${{ matrix.patroni_version }}
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.sha }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
-    
-    - name: Push image to Docker Hub
-      if: steps.check_secrets.outputs.secrets_available == 'true'
-      uses: docker/build-push-action@v7.0.0
-      with:
-        context: .
-        build-args: |
-          DISTRO=${{ matrix.distro }}
-          PG_VERSION=${{ matrix.pg_version }}
-          PATRONI_VERSION=${{ matrix.patroni_version }}
-          GITHUB_REPOSITORY=${{ github.repository }}
-          GITHUB_SHA=${{ github.sha }}
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: docker.io/${{ env.LOWER_IMAGE_TAG }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6.0.0
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+      - name: Debug tags
+        run: |
+          echo "Tags:"
+          for tag in ${{ steps.meta.outputs.tags }}; do
+          echo "$tag"
+          done
+      - name: Extract tags without registry and image name
+        id: extract-tags
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" |  tr ',' '\n' | sed 's|.*/||; s|.*:||' > tags.txt
+          echo "TAGS=$(cat tags.txt | tr '\n' ',' | sed 's|,$||')" >> $GITHUB_ENV
+      - name: Override base tag with custom input (if provided)
+        run: |
+          BASE_TAG="${{ env.TAGS }}"
+          if [ -n "${{ inputs.tag }}" ]; then
+            BASE_TAG="${{ inputs.tag }}"
+            echo "Custom tag '${{ inputs.tag }}' will be use as base tag"
+          else
+            echo "Custom tag is not set → use tag from metadata: $BASE_TAG"
+          fi
+          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
 
-    - name: Install cosign
-      if: github.event_name != 'pull_request'
-      uses: sigstore/cosign-installer@v4.1.2
+      - name: Build final LOWER_IMAGE_TAG
+        run: |
+          FINAL="${{ env.IMAGE_NAME }}:${BASE_TAG}-${{ matrix.pg_version }}-${{ matrix.patroni_version }}-${{ matrix.distro }}"
+          echo "LOWER_IMAGE_TAG=$(echo "$FINAL" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "Final tag → ghcr.io/${{ env.LOWER_IMAGE_TAG }}"
+      - name: Export final base tag
+        id: set-tag
+        run: echo "tag=${BASE_TAG}" >> $GITHUB_OUTPUT
+      - name: Build Docker image for platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
+        id: build_image
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            DISTRO=${{ matrix.distro }}
+            PG_VERSION=${{ matrix.pg_version }}
+            PATRONI_VERSION=${{ matrix.patroni_version }}
+            GITHUB_REPOSITORY=${{ github.repository }}
+            GITHUB_SHA=${{ github.sha }}
+          platforms: ${{ matrix.platform }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: false
+          tags: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Test Docker image platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
+        if: github.event_name == 'pull_request'
+        run: |
+          IMAGE="ghcr.io/${{ env.LOWER_IMAGE_TAG }}"
+          echo "Testing image: $IMAGE  (platform: ${{ matrix.platform }})"
+          if [ "${{ matrix.platform }}" = "linux/arm64" ]; then
+            echo "ARM64 → use QEMU"
+            docker run --rm --platform linux/arm64 "$IMAGE" patroni --version
+            docker run --rm --platform linux/arm64 --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
+          else
+            docker run --rm "$IMAGE" patroni --version
+            docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'postgres --version'
+          fi
+      - name: Scan image for vulnerabilities (Trivy)
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+      - name: Push image to GITHUB registry
+        id: push-ghcr
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          build-args: |
+            DISTRO=${{ matrix.distro }}
+            PG_VERSION=${{ matrix.pg_version }}
+            PATRONI_VERSION=${{ matrix.patroni_version }}
+            GITHUB_REPOSITORY=${{ github.repository }}
+            GITHUB_SHA=${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
 
-    - name: Sign published GHCR image
-      if: github.event_name != 'pull_request'
-      env:
-        DIGEST: ${{ steps.push-ghcr.outputs.digest }}
-      run: |
-        cosign sign --yes "ghcr.io/${{ env.IMAGE_NAME }}@${DIGEST}"
-    
+      - name: Push image to Docker Hub
+        if: steps.check_secrets.outputs.secrets_available == 'true'
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          build-args: |
+            DISTRO=${{ matrix.distro }}
+            PG_VERSION=${{ matrix.pg_version }}
+            PATRONI_VERSION=${{ matrix.patroni_version }}
+            GITHUB_REPOSITORY=${{ github.repository }}
+            GITHUB_SHA=${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: docker.io/${{ env.LOWER_IMAGE_TAG }}
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
+      - name: Sign published GHCR image
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.push-ghcr.outputs.digest }}
+        run: |
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_NAME }}@${DIGEST}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/arm64]
         distro: [trixie, alpine]
-        pg_version: ['17.6', '18.0']
+        pg_version: ['17.10', '18.4']
         patroni_version: [4.0.7]
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,8 @@ docker build \
 
 Smoke-test that the binaries start. The image's ENTRYPOINT is
 `/usr/bin/patroni`, which silently ignores unknown args, so to actually run
-`postgres` you must override the entrypoint (CI's `postgres --version` step does
-not, making it a no-op):
+`postgres` you must override the entrypoint (the CI `postgres --version` step
+does this too — see the CI/CD section):
 
 ```sh
 docker run --rm patroni-docker:local-alpine-17.10 patroni --version
@@ -111,9 +111,10 @@ Python/Postgres dependencies.
 **Security hardening (both paths).** Each install path upgrades base-image
 packages to clear HIGH/CRITICAL CVEs (gated by the Trivy scan in CI): alpine
 runs `apk upgrade --no-cache`; trixie runs `apt-get upgrade -y` but first
-`apt-mark hold`s `postgresql-<major>` / `postgresql-client-<major>` (major
-derived from `/usr/lib/postgresql/`) so the upgrade patches library CVEs
-(openssl, gnutls, …) **without bumping the PostgreSQL point release** away
+`apt-mark hold`s `postgresql-<major>` / `postgresql-client-<major>`, where
+`<major>` is the `PG_MAJOR` environment variable already set by the official
+`postgres` base image (e.g. `17`). The hold lets the upgrade patch library
+CVEs (openssl, gnutls, …) **without bumping the PostgreSQL point release** away
 from the matrix-pinned version — the image tag must stay honest. Both paths
 also `rm -f /usr/local/bin/gosu`: gosu is a Go binary shipped by the stock
 `postgres` image that carries Go-stdlib CVEs, and it is unused here (our
@@ -141,6 +142,12 @@ to override the base tag). Per matrix cell it:
 5. pushes to `docker.io` **only if Docker Hub secrets are present**,
 6. signs the published GHCR image with **cosign** keyless (OIDC) **on non-PRs**.
    Cosign runs *last*, so a signing failure does not block publication.
+
+**Known limitation:** the Trivy gate runs on **PRs only**. Images published
+from `main`/tags are not re-scanned at publish time (the publish path doesn't
+load the image into the runner — see landmine #3). So a CVE disclosed *after*
+a PR is approved can still ship to the registries; the gate catches what was
+present at PR time. Only the GHCR image is signed; Docker Hub images are not.
 
 Registries and the secrets that gate them:
 
@@ -224,6 +231,16 @@ These are real, verified traps in the current tree:
    then pushes with two more `build-push-action` invocations (ghcr, then Docker
    Hub). Don't "optimize" this into a single `push:` step without confirming the
    PR smoke-test path still works, since `load:` is only set on the first step.
+
+4. **Builds are time-sensitive and not byte-reproducible.** Both install paths
+   run an unbounded package upgrade (`apk upgrade` / `apt-get upgrade`) to pull
+   the latest security fixes, so the same Dockerfile + args can produce
+   different images days apart. Consequence: CI on an **unchanged** commit can
+   flip green→red if a new fixable HIGH/CRITICAL CVE appears against a base
+   package, or if a fix lands on the mirrors between the PR scan and the
+   post-merge build. `ignore-unfixed: true` mitigates (unfixed CVEs don't fail
+   the gate) but does not eliminate this. The fix for a red scan is a
+   base-image/package bump, not disabling the gate.
 
 ## Workflow conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,11 @@ image ref is `ghcr.io/batonogov/patroni-docker:<tag>` and
 
 ## Building locally
 
+A `.dockerignore` excludes everything except `Dockerfile` (the Dockerfile does
+not COPY/ADD any context files), so the build context is a few KB even though
+the working tree contains ~200 MB of local Postgres data under
+`examples/docker/patroni-data*`.
+
 `DISTRO` (default `trixie`) and `PG_VERSION` (default `17.6`) are optional;
 `PATRONI_VERSION` is the only required arg. A bare `docker build .` fails
 loudly unless you pass `--build-arg PATRONI_VERSION=…`.
@@ -110,9 +115,16 @@ Python/Postgres dependencies.
 to override the base tag). Per matrix cell it:
 
 1. builds the image (`docker/build-push-action`, `load:` on PRs, `push:false`),
-2. runs the `patroni --version` / `postgres --version` smoke test **on PRs only**,
-3. pushes to `ghcr.io` (always, except PRs),
-4. pushes to `docker.io` **only if Docker Hub secrets are present**.
+2. runs the `patroni --version` + `postgres --version` smoke test **on PRs only**
+   (the `postgres` check overrides the patroni ENTRYPOINT via `--entrypoint
+   /bin/sh`, otherwise patroni would swallow the arg and it would be a no-op),
+3. scans the loaded image with **Trivy** (`HIGH,CRITICAL`, `exit-code: 1`) **on
+   PRs only** — this is the vulnerability gate before merge,
+4. pushes to `ghcr.io` (always, except PRs) and exposes its digest as
+   `steps.push-ghcr.outputs.digest`,
+5. pushes to `docker.io` **only if Docker Hub secrets are present**,
+6. signs the published GHCR image with **cosign** keyless (OIDC) **on non-PRs**.
+   Cosign runs *last*, so a signing failure does not block publication.
 
 Registries and the secrets that gate them:
 
@@ -123,8 +135,8 @@ Registries and the secrets that gate them:
   skipped silently; this is intentional, not a failure.
 
 The job grants `packages: write` (to push to ghcr) and `id-token: write`
-(intended for future keyless signing via OIDC; currently unused — there is no
-cosign step). The build uses `cache-from/to: type=gha`.
+(used for keyless cosign signing of the published image via GitHub OIDC). The
+build uses `cache-from/to: type=gha`.
 
 ## Examples (reference deployments, not production)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,15 +38,15 @@ When you change any of these, you change the whole published surface:
 |------------------|-------------------------|
 | `platform`       | `linux/amd64`, `linux/arm64` |
 | `distro`         | `trixie`, `alpine`      |
-| `pg_version`     | `17.6`, `18.0`          |
+| `pg_version`     | `17.10`, `18.4`         |
 | `patroni_version`| `4.0.7`                 |
 
 The image tag is built deterministically as:
 
 ```
 ${BASE_TAG}-${pg_version}-${patroni_version}-${distro}   # lowercased
-# example on a push to main:  main-17.6-4.0.7-trixie
-# example for a tag v1.2.3 :  v1.2.3-17.6-4.0.7-alpine
+# example on a push to main:  main-17.10-4.0.7-trixie
+# example for a tag v1.2.3 :  v1.2.3-17.10-4.0.7-alpine
 ```
 
 `BASE_TAG` comes from `docker/metadata-action` (branch name, git tag, or PR
@@ -61,16 +61,16 @@ not COPY/ADD any context files), so the build context is a few KB even though
 the working tree contains ~200 MB of local Postgres data under
 `examples/docker/patroni-data*`.
 
-`DISTRO` (default `trixie`) and `PG_VERSION` (default `17.6`) are optional;
+`DISTRO` (default `trixie`) and `PG_VERSION` (default `17.10`) are optional;
 `PATRONI_VERSION` is the only required arg. A bare `docker build .` fails
 loudly unless you pass `--build-arg PATRONI_VERSION=…`.
 
 ```sh
 docker build \
   --build-arg DISTRO=alpine \
-  --build-arg PG_VERSION=17.6 \
+  --build-arg PG_VERSION=17.10 \
   --build-arg PATRONI_VERSION=4.0.7 \
-  -t patroni-docker:local-alpine-17.6 \
+  -t patroni-docker:local-alpine-17.10 \
   .
 ```
 
@@ -80,8 +80,8 @@ Smoke-test that the binaries start. The image's ENTRYPOINT is
 not, making it a no-op):
 
 ```sh
-docker run --rm patroni-docker:local-alpine-17.6 patroni --version
-docker run --rm --entrypoint /bin/sh patroni-docker:local-alpine-17.6 -c 'postgres --version'
+docker run --rm patroni-docker:local-alpine-17.10 patroni --version
+docker run --rm --entrypoint /bin/sh patroni-docker:local-alpine-17.10 -c 'postgres --version'
 ```
 
 > Building `linux/arm64` on an amd64 host requires QEMU/binfmt; CI sets that up
@@ -107,6 +107,22 @@ The single `Dockerfile` branches on `DISTRO`:
 Both paths: run as the `postgres` user, `ENTRYPOINT ["/usr/bin/patroni"]`,
 `CMD ["/etc/patroni/config.yml"]`. Keep the two paths in sync when adding
 Python/Postgres dependencies.
+
+**Security hardening (both paths).** Each install path upgrades base-image
+packages to clear HIGH/CRITICAL CVEs (gated by the Trivy scan in CI): alpine
+runs `apk upgrade --no-cache`; trixie runs `apt-get upgrade -y` but first
+`apt-mark hold`s `postgresql-<major>` / `postgresql-client-<major>` (major
+derived from `/usr/lib/postgresql/`) so the upgrade patches library CVEs
+(openssl, gnutls, …) **without bumping the PostgreSQL point release** away
+from the matrix-pinned version — the image tag must stay honest. Both paths
+also `rm -f /usr/local/bin/gosu`: gosu is a Go binary shipped by the stock
+`postgres` image that carries Go-stdlib CVEs, and it is unused here (our
+entrypoint is patroni running as the non-root `postgres` user; patroni never
+shells out to gosu). Removing it clears those CVEs and shaves ~2 MB.
+
+The pg_version baseline (`17.10`, `18.4`) is chosen so the base image already
+contains the PostgreSQL-server CVE fixes; do not let it fall behind the
+fixed-in version of any open CVE, or the Trivy gate will fail.
 
 ## CI/CD
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DISTRO=trixie
-ARG PG_VERSION=17.6
+ARG PG_VERSION=17.10
 FROM postgres:${PG_VERSION}-${DISTRO}
 
 ARG PATRONI_VERSION
@@ -19,6 +19,7 @@ LABEL org.opencontainers.image.revision="${GITHUB_SHA}"
 RUN echo "DISTRO is: ${DISTRO}"  && echo "PATRONI_VERSION is: ${PATRONI_VERSION}" && \
     if [ "${DISTRO}" = "alpine" ]; then \
       apk update \
+      && apk upgrade --no-cache \
       && apk add --no-cache \
         musl-locales \
         python3 \
@@ -32,6 +33,9 @@ RUN echo "DISTRO is: ${DISTRO}"  && echo "PATRONI_VERSION is: ${PATRONI_VERSION}
       && rm -rf /var/cache/apk/*; \
     else \
       apt update \
+      && PG_MAJOR=$(ls /usr/lib/postgresql) \
+      && apt-mark hold postgresql-${PG_MAJOR} postgresql-client-${PG_MAJOR} \
+      && apt-get upgrade -y \
       && PATRONI_DEB_VERSION=$(apt-cache madison patroni \
            | awk -F'|' '{ gsub(/[ \t]/, "", $2); print $2 }' \
            | grep -m1 "^${PATRONI_VERSION}-" || true) \
@@ -49,7 +53,8 @@ RUN echo "DISTRO is: ${DISTRO}"  && echo "PATRONI_VERSION is: ${PATRONI_VERSION}
     fi \
     && mkdir -p /var/lib/postgresql \
     && chown postgres:postgres /var/lib/postgresql \
-    && chmod 700 /var/lib/postgresql
+    && chmod 700 /var/lib/postgresql \
+    && rm -f /usr/local/bin/gosu
 
 USER postgres
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN echo "DISTRO is: ${DISTRO}"  && echo "PATRONI_VERSION is: ${PATRONI_VERSION}
       && rm -rf /var/cache/apk/*; \
     else \
       apt update \
-      && PG_MAJOR=$(ls /usr/lib/postgresql) \
       && apt-mark hold postgresql-${PG_MAJOR} postgresql-client-${PG_MAJOR} \
       && apt-get upgrade -y \
       && PATRONI_DEB_VERSION=$(apt-cache madison patroni \


### PR DESCRIPTION
## Summary

Four security/correctness improvements to the CI pipeline and build context. Three are verified locally; Trivy/cosign are CI-verified by this PR's run.

| Change | What | Verified |
|--------|------|----------|
| `.dockerignore` | Exclude everything except `Dockerfile` | ✅ local: context 209 MB → 5.12 KB |
| Smoke-test fix | `postgres --version` was a no-op (patroni ENTRYPOINT swallowed the arg) | ✅ local: was printing `patroni 4.0.7`, now `postgres (PostgreSQL) 17.6` |
| Trivy scan (PR-only) | Vulnerability gate for HIGH/CRITICAL before merge | CI (this PR) |
| Cosign signing (push-only) | Keyless sign of published GHCR image via OIDC | CI (on merge to main) |

## 1. `.dockerignore` (new file)

The Dockerfile does not COPY/ADD any repository files, so the build context only needs the Dockerfile itself. The working tree contains ~200 MB of **local gitignored** Postgres data under `examples/docker/patroni-data*` that was being uploaded to the builder on every build. Now:

```
Sending build context to Docker daemon  5.12kB   (was ~209 MB)
```

Side benefit: local runtime artifacts can never leak into a build.

## 2. Smoke-test no-op fix

The image's ENTRYPOINT is `/usr/bin/patroni`. The PR-path test step ran:
```
docker run --rm "$IMAGE" postgres --version
```
which actually executes `patroni postgres --version` — patroni ignores unknown args and prints **its own** version. The "postgres check" therefore never exercised postgres. Confirmed locally:
- before: `patroni 4.0.7`
- after (`--entrypoint /bin/sh -c 'postgres --version'`): `postgres (PostgreSQL) 17.6`

## 3. Trivy vulnerability scan

`aquasecurity/trivy-action@v0.36.0`, PR-only, after the test step:
```yaml
image-ref: ghcr.io/${{ env.LOWER_IMAGE_TAG }}
severity: HIGH,CRITICAL
exit-code: '1'
ignore-unfixed: true
```
Runs only on PRs because the build step loads the image to the runner only on the PR path (`load: ${{ github.event_name == 'pull_request' }}`; the push path uses `load:false`+`push:false` on the first step, see existing landmine). This makes the scan a merge gate.

> ⚠️ **Risk:** a brand-new HIGH/CRITICAL CVE in the base image or patroni could turn this PR red. If so, the fix is a base-image/patroni bump, not disabling the scan.

## 4. Cosign keyless signing

`sigstore/cosign-installer@v4.1.2`, **push-only**, placed **after both push steps**:
```yaml
- name: Sign published GHCR image
  if: github.event_name != 'pull_request'
  env:
    DIGEST: ${{ steps.push-ghcr.outputs.digest }}
  run: cosign sign --yes "ghcr.io/${{ env.IMAGE_NAME }}@${DIGEST}"
```
- Uses GitHub OIDC (`id-token: write` is already on the job — previously unused).
- Signs by digest of the actually-published GHCR image (the push step gained `id: push-ghcr` to expose `outputs.digest`).
- Positioned last so a signing failure **does not block** image publication.

## Design notes / scope

- Did **not** refactor the existing triple-build (build, push-ghcr, push-dockerhub each rebuild) — that is a separate landmine; this PR stays minimal.
- Did **not** change multi-arch strategy (still 2 matrix jobs via QEMU); cosign signs each per-arch manifest digest.
- Did not pin Trivy DB — it updates at action run time, which is the recommended posture.

## Test plan
- [x] `.dockerignore`: context size verified locally (209 MB → 5.12 KB)
- [x] Smoke-test: postgres version now actually printed
- [ ] Full 8-cell CI matrix green on this PR (verifies trivy doesn't false-positive on current images)
- [ ] On merge to main: cosign signs the published images (verify via `cosign verify` afterwards)
