### PR TITLE
chore: ignore .pi/ agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ secrets
 patroni-data*
 .ansible
 .fake
+.pi


### PR DESCRIPTION
### Summary

Add `.pi` to `.gitignore` so the Pi coding agent's working artifacts (review notes, plans, scratch files) under `.pi/` stop showing as untracked.

### Why

Per the project convention in `AGENTS.md` ("Artifacts and Working Files"), agent artifacts that are not part of the deliverable live under the project's `.pi/` directory and must not be committed. Until now `.pi/` was not git-ignored, so it cluttered every `git status`.

### Changes

- `.gitignore`: add `.pi` (also adds the missing trailing newline — `end-of-file-fixer`, already in `.pre-commit-config.yaml`, requires it; the file previously violated it).

Diff: 1 file, +2 / −1.