### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,17 +37,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up QEMU
         if: ${{ matrix.platform }} == 'linux/arm64'
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log into GITHUB registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
           fi
       - name: Log into Docker Hub
         if: steps.check_secrets.outputs.secrets_available == 'true'
-        uses: docker/login-action@v4.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_REGISTRY_USERNAME }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.1.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ env.IMAGE_NAME }}
       - name: Debug tags
@@ -105,7 +105,7 @@ jobs:
         run: echo "tag=${BASE_TAG}" >> $GITHUB_OUTPUT
       - name: Build Docker image for platform ${{ matrix.platform }} Distribution ${{ matrix.distro }} PostgreSQL ${{ matrix.pg_version }} Patroni ${{ matrix.patroni_version }}
         id: build_image
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
@@ -145,7 +145,7 @@ jobs:
           ignore-unfixed: true
       - name: Push image to GITHUB registry
         id: push-ghcr
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           build-args: |
@@ -159,7 +159,7 @@ jobs:
 
       - name: Push image to Docker Hub
         if: steps.check_secrets.outputs.secrets_available == 'true'
-        uses: docker/build-push-action@v7.2.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           build-args: |


### PR DESCRIPTION
Replace all @vX version tags with commit SHA pins for security.

Pinned `@vX` and `@vX.X.X` tags to their exact commit SHAs with trailing version comments. The already-SHA-pinned trivy and cosign actions were left untouched.

Actions pinned in this repo:
- actions/checkout
- docker/setup-qemu-action, setup-buildx-action, login-action, metadata-action, build-push-action